### PR TITLE
Fix incorrect annotation syntax from #[\Override] to #[Override]

### DIFF
--- a/src/Bitrix24Accounts/Entity/Bitrix24Account.php
+++ b/src/Bitrix24Accounts/Entity/Bitrix24Account.php
@@ -20,6 +20,7 @@ use Bitrix24\SDK\Core\Exceptions\InvalidArgumentException;
 use Bitrix24\SDK\Core\Exceptions\UnknownScopeCodeException;
 use Bitrix24\SDK\Core\Response\DTO\RenewedAuthToken;
 use Carbon\CarbonImmutable;
+use Override;
 use Symfony\Component\Uid\Uuid;
 
 class Bitrix24Account implements Bitrix24AccountInterface
@@ -56,43 +57,43 @@ class Bitrix24Account implements Bitrix24AccountInterface
         $this->applicationScope = $applicationScope->getScopeCodes();
     }
 
-    #[\Override]
+    #[Override]
     public function getId(): Uuid
     {
         return $this->id;
     }
 
-    #[\Override]
+    #[Override]
     public function getBitrix24UserId(): int
     {
         return $this->bitrix24UserId;
     }
 
-    #[\Override]
+    #[Override]
     public function isBitrix24UserAdmin(): bool
     {
         return $this->isBitrix24UserAdmin;
     }
 
-    #[\Override]
+    #[Override]
     public function getMemberId(): string
     {
         return $this->memberId;
     }
 
-    #[\Override]
+    #[Override]
     public function getDomainUrl(): string
     {
         return $this->domainUrl;
     }
 
-    #[\Override]
+    #[Override]
     public function getStatus(): Bitrix24AccountStatus
     {
         return $this->accountStatus;
     }
 
-    #[\Override]
+    #[Override]
     public function getAuthToken(): AuthToken
     {
         return new AuthToken($this->accessToken, $this->refreshToken, $this->expires);
@@ -101,7 +102,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function renewAuthToken(RenewedAuthToken $renewedAuthToken): void
     {
         if ($this->memberId !== $renewedAuthToken->memberId) {
@@ -122,7 +123,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
         $this->updatedAt = new CarbonImmutable();
     }
 
-    #[\Override]
+    #[Override]
     public function getApplicationVersion(): int
     {
         return $this->applicationVersion;
@@ -131,7 +132,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws UnknownScopeCodeException
      */
-    #[\Override]
+    #[Override]
     public function getApplicationScope(): Scope
     {
         return new Scope($this->applicationScope);
@@ -140,7 +141,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function changeDomainUrl(string $newDomainUrl): void
     {
         if ($newDomainUrl === '') {
@@ -165,7 +166,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function applicationInstalled(string $applicationToken): void
     {
         if (Bitrix24AccountStatus::new !== $this->accountStatus) {
@@ -186,7 +187,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function applicationUninstalled(string $applicationToken): void
     {
         if ($applicationToken === '') {
@@ -215,19 +216,19 @@ class Bitrix24Account implements Bitrix24AccountInterface
         $this->updatedAt = new CarbonImmutable();
     }
 
-    #[\Override]
+    #[Override]
     public function isApplicationTokenValid(string $applicationToken): bool
     {
         return $this->applicationToken === $applicationToken;
     }
 
-    #[\Override]
+    #[Override]
     public function getCreatedAt(): CarbonImmutable
     {
         return $this->createdAt;
     }
 
-    #[\Override]
+    #[Override]
     public function getUpdatedAt(): CarbonImmutable
     {
         return $this->updatedAt;
@@ -236,7 +237,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function updateApplicationVersion(int $version, ?Scope $newScope): void
     {
         if (Bitrix24AccountStatus::active !== $this->accountStatus) {
@@ -261,7 +262,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function markAsActive(?string $comment): void
     {
         if (Bitrix24AccountStatus::blocked !== $this->accountStatus) {
@@ -278,7 +279,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
     /**
      * @throws InvalidArgumentException
      */
-    #[\Override]
+    #[Override]
     public function markAsBlocked(?string $comment): void
     {
         if (Bitrix24AccountStatus::deleted === $this->accountStatus) {
@@ -290,7 +291,7 @@ class Bitrix24Account implements Bitrix24AccountInterface
         $this->updatedAt = new CarbonImmutable();
     }
 
-    #[\Override]
+    #[Override]
     public function getComment(): ?string
     {
         return $this->comment;


### PR DESCRIPTION
Corrected the syntax of the #[Override] annotation throughout the Bitrix24Account.php file. This ensures proper usage of the attribute without the unnecessary backslash, improving code readability and consistency.